### PR TITLE
New, more functional DSL + remove of the need to declare guard_transition/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ end
 
 ### Declaring States
 
-Declare the states you'll have when importing `Machinery` on the module
-that will control your states transitions.
+Declare the states you need pasing it as an argment when importing `Machinery`
+on the module that will control your states transitions.
 
 Machinery expects a `Keyword` as argument with two keys `states` and `transitions`.
 
@@ -41,8 +41,7 @@ Machinery expects a `Keyword` as argument with two keys `states` and `transition
 ```elixir
 defmodule YourProject.UserStateMachine do
   use Machinery,
-    # The first state declared will be
-    # considered the intial state
+    # The first state declared will be considered the intial state
     states: [:created, :partial, :complete],
     transitions: %{
       created: [:partial, :complete],
@@ -53,26 +52,29 @@ defmodule YourProject.UserStateMachine do
   # of the guard_transition/2 function, pattern matching
   # the desired state you want to guard.
   #
-  # Return true: Guard clause will allow the transition
-  # Return false: Transition won't be allowed
+  # Guard conditions should return a boolean:
+  # true: Guard clause will allow the transition
+  # false: Transition won't be allowed
   #
-  defp guard_transition(struct, :complete) do
+  def guard_transition(struct, :complete) do
    Map.get(struct, :missing_fields) == false
   end
 
   ############
   # REQUIRED: It's required for you to include this function.
   # it will act as fallback for states that don't have guard functions.
-  # Allowing their transactions.
+  # Allowing their transitons to go through
   ############
-  defp guard_transition(_struct, _state), do: true
+  def guard_transition(_struct, _state), do: true
 end
 ```
 
 ## Usage
 
-To transit a struct into another state, you just need to call the
-`Module.transition_to(your_struct, :next_state)`.
+To transit a struct into another state, you just need to call `Machinery.transition_to/2`
+```elixir
+Machinery.transition_to(your_struct, :next_state)
+```
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ defmodule YourProject.UserStateMachine do
       partial: :completed
     }
 
-  # Create guard conditions by adding new signatures
-  # of the guard_transition/2 function, pattern matching
-  # the desired state you want to guard.
+  # Create guard conditions by adding signatures of the
+  # guard_transition/2 function, pattern matching the
+  # desired state you want to guard.
   #
   # Guard conditions should return a boolean:
   # true: Guard clause will allow the transition
@@ -59,13 +59,6 @@ defmodule YourProject.UserStateMachine do
   def guard_transition(struct, :complete) do
    Map.get(struct, :missing_fields) == false
   end
-
-  ############
-  # REQUIRED: It's required for you to include this function.
-  # it will act as fallback for states that don't have guard functions.
-  # Allowing their transitons to go through
-  ############
-  def guard_transition(_struct, _state), do: true
 end
 ```
 

--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -43,6 +43,7 @@ defmodule Machinery do
       states: states,
       transitions: transitions
     ] do
+      @behaviour Machinery.StructBehaviour
 
       # Functions to hold and expose internal info of the states.
       def _machinery_initial_state(), do: List.first(unquote(states))

--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -97,12 +97,10 @@ defmodule Machinery do
   # transitions are permitted unless another existing
   # guard condition exists.
   defp guard_transition(module, struct, next_state) do
-    try do
-      module.guard_transition(struct,next_state)
-    rescue
-      error in UndefinedFunctionError -> guard_transition_fallback?(error)
-      error in FunctionClauseError -> guard_transition_fallback?(error)
-    end
+    module.guard_transition(struct, next_state)
+  rescue
+    error in UndefinedFunctionError -> guard_transition_fallback?(error)
+    error in FunctionClauseError -> guard_transition_fallback?(error)
   end
 
   # Private function to check if the transition is allowed.

--- a/lib/machinery/struct_behaviour.ex
+++ b/lib/machinery/struct_behaviour.ex
@@ -1,8 +1,0 @@
-defmodule Machinery.StructBehaviour do
-  @moduledoc """
-  Behaviour that will be implemented in the module of the struct
-  using Machinery
-  """
-
-  @callback guard_transition(struct, atom) :: boolean
-end

--- a/lib/machinery/struct_behaviour.ex
+++ b/lib/machinery/struct_behaviour.ex
@@ -1,0 +1,8 @@
+defmodule Machinery.StructBehaviour do
+  @moduledoc """
+  Behaviour that will be implemented in the module of the struct
+  using Machinery
+  """
+
+  @callback guard_transition(struct, atom) :: boolean
+end

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -4,6 +4,9 @@ defmodule MachineryTest do
   doctest Machinery
 
   defmodule TestModule do
+
+    defstruct state: nil, missing_fields: nil
+
     use Machinery,
       states: [:created, :partial, :completed],
       transitions: %{
@@ -11,34 +14,34 @@ defmodule MachineryTest do
         partial: :completed
       }
 
-    defp guard_transition(struct, :completed) do
+    def guard_transition(struct, :completed) do
       Map.get(struct, :missing_fields) == false
     end
-    defp guard_transition(_struct, _state), do: true
+
+    def guard_transition(_struct, _state), do: true
   end
 
-  test "All transition_to methods for each state were injected into AST" do
-    assert :erlang.function_exported(TestModule, :transition_to, 2)
-    assert TestModule.transition_to(%{}, :created)
-    assert TestModule.transition_to(%{}, :partial)
-    assert TestModule.transition_to(%{}, :completed)
+  test "All internal functions should be injected into AST" do
+    assert :erlang.function_exported(TestModule, :_machinery_initial_state, 0)
+    assert :erlang.function_exported(TestModule, :_machinery_states, 0)
+    assert :erlang.function_exported(TestModule, :_machinery_transitions, 0)
   end
 
   test "Only the declared transitions should be valid" do
-    assert {:ok, %{state: :partial}} = TestModule.transition_to(%{state: :created}, :partial)
-    assert {:ok, %{state: :completed, missing_fields: false}} = TestModule.transition_to(%{state: :created, missing_fields: false}, :completed)
-    assert {:ok, %{state: :completed, missing_fields: false}} = TestModule.transition_to(%{state: :partial, missing_fields: false}, :completed)
-    assert {:error, "Transition to this state isn't allowed"} = TestModule.transition_to(%{}, :created)
-    assert {:error, "Transition to this state isn't allowed"} = TestModule.transition_to(%{state: :completed}, :created)
+    assert {:ok, %TestModule{state: :partial}} = Machinery.transition_to(%TestModule{state: :created}, :partial)
+    assert {:ok, %TestModule{state: :completed, missing_fields: false}} = Machinery.transition_to(%TestModule{state: :created, missing_fields: false}, :completed)
+    assert {:ok, %TestModule{state: :completed, missing_fields: false}} = Machinery.transition_to(%TestModule{state: :partial, missing_fields: false}, :completed)
+    assert {:error, "Transition to this state isn't allowed"} = Machinery.transition_to(%TestModule{}, :created)
+    assert {:error, "Transition to this state isn't allowed"} = Machinery.transition_to(%TestModule{state: :completed}, :created)
   end
 
   test "Guard functions should be executed before moving the resource to the next state" do
-    struct = %{state: :created, missing_fields: true}
-    assert {:error, "Transition not completed, blocked by guard function"} = TestModule.transition_to(struct, :completed)
+    struct = %TestModule{state: :created, missing_fields: true}
+    assert {:error, "Transition not completed, blocked by guard function"} = Machinery.transition_to(struct, :completed)
   end
 
   test "The first declared state should be considered the initial one" do
-    stateless_struct = %{}
-    assert {:ok, %{state: :partial}} = TestModule.transition_to(stateless_struct, :partial)
+    stateless_struct = %TestModule{}
+    assert {:ok, %TestModule{state: :partial}} = Machinery.transition_to(stateless_struct, :partial)
   end
 end

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -17,8 +17,6 @@ defmodule MachineryTest do
     def guard_transition(struct, :completed) do
       Map.get(struct, :missing_fields) == false
     end
-
-    def guard_transition(_struct, _state), do: true
   end
 
   test "All internal functions should be injected into AST" do

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -1,11 +1,12 @@
 defmodule MachineryTest do
   use ExUnit.Case
-  alias MachineryTest.TestModule
   doctest Machinery
 
-  defmodule TestModule do
+  alias MachineryTest.TestModule
+  alias MachineryTest.TestModuleWithGuard
 
-    defstruct state: nil, missing_fields: nil
+  defmodule TestModuleWithGuard do
+    defstruct state: nil, missing_fields: nil, force_exception: false
 
     use Machinery,
       states: [:created, :partial, :completed],
@@ -15,8 +16,26 @@ defmodule MachineryTest do
       }
 
     def guard_transition(struct, :completed) do
+
+      # Code to unquote code into this AST that
+      # will force and exception.
+      if Map.get(struct, :force_exception) do
+        Machinery.non_existing_function_should_raise_error()
+      end
+
       Map.get(struct, :missing_fields) == false
     end
+  end
+
+  defmodule TestModule do
+    defstruct state: nil, missing_fields: nil
+
+    use Machinery,
+      states: [:created, :partial, :completed],
+      transitions: %{
+        created: [:partial, :completed],
+        partial: :completed
+      }
   end
 
   test "All internal functions should be injected into AST" do
@@ -26,20 +45,45 @@ defmodule MachineryTest do
   end
 
   test "Only the declared transitions should be valid" do
-    assert {:ok, %TestModule{state: :partial}} = Machinery.transition_to(%TestModule{state: :created}, :partial)
-    assert {:ok, %TestModule{state: :completed, missing_fields: false}} = Machinery.transition_to(%TestModule{state: :created, missing_fields: false}, :completed)
-    assert {:ok, %TestModule{state: :completed, missing_fields: false}} = Machinery.transition_to(%TestModule{state: :partial, missing_fields: false}, :completed)
-    assert {:error, "Transition to this state isn't allowed"} = Machinery.transition_to(%TestModule{}, :created)
-    assert {:error, "Transition to this state isn't allowed"} = Machinery.transition_to(%TestModule{state: :completed}, :created)
+    created_struct = %TestModuleWithGuard{state: :created, missing_fields: false}
+    partial_struct = %TestModuleWithGuard{state: :partial, missing_fields: false}
+    stateless_struct = %TestModuleWithGuard{}
+    completed_struct = %TestModuleWithGuard{state: :completed}
+
+    assert {:ok, %TestModuleWithGuard{state: :partial}} = Machinery.transition_to(created_struct, :partial)
+    assert {:ok, %TestModuleWithGuard{state: :completed, missing_fields: false}} = Machinery.transition_to(created_struct, :completed)
+    assert {:ok, %TestModuleWithGuard{state: :completed, missing_fields: false}} = Machinery.transition_to(partial_struct, :completed)
+    assert {:error, "Transition to this state isn't allowed"} = Machinery.transition_to(stateless_struct, :created)
+    assert {:error, "Transition to this state isn't allowed"} = Machinery.transition_to(completed_struct, :created)
   end
 
   test "Guard functions should be executed before moving the resource to the next state" do
-    struct = %TestModule{state: :created, missing_fields: true}
+    struct = %TestModuleWithGuard{state: :created, missing_fields: true}
     assert {:error, "Transition not completed, blocked by guard function"} = Machinery.transition_to(struct, :completed)
   end
 
+  test "Guard functions should allow or block transitions" do
+    allowed_struct = %TestModuleWithGuard{state: :created, missing_fields: false}
+    blocked_struct = %TestModuleWithGuard{state: :created, missing_fields: true}
+
+    assert {:ok, %TestModuleWithGuard{state: :completed, missing_fields: false}} = Machinery.transition_to(allowed_struct, :completed)
+    assert {:error, "Transition not completed, blocked by guard function"} = Machinery.transition_to(blocked_struct, :completed)
+  end
+
   test "The first declared state should be considered the initial one" do
-    stateless_struct = %TestModule{}
-    assert {:ok, %TestModule{state: :partial}} = Machinery.transition_to(stateless_struct, :partial)
+    stateless_struct = %TestModuleWithGuard{}
+    assert {:ok, %TestModuleWithGuard{state: :partial}} = Machinery.transition_to(stateless_struct, :partial)
+  end
+
+  test "Modules without guard conditions should allow transitions by default" do
+    struct = %TestModule{state: :created, missing_fields: true}
+    assert {:ok, %TestModule{state: :completed, missing_fields: true}} = Machinery.transition_to(struct, :completed)
+  end
+
+  test "Implict rescue on the guard clause internals should raise any other excepetion not strictly related to missing guard_tranistion/2 existence" do
+    wrong_struct = %TestModuleWithGuard{state: :created, force_exception: true}
+    assert_raise UndefinedFunctionError, fn() ->
+      Machinery.transition_to(wrong_struct, :completed)
+    end
   end
 end


### PR DESCRIPTION
The current DSL on macros more than it should, this new DSL, is more function and also enables Machinery to have a default fallback behavior to the guard transitions.