### PR TITLE
Adding first version of before and after callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # ChangeLog
 
 ## WIP Version
-- New, more functional DSL, not relying on Macros so much [Pull Request](https://github.com/joaomdmoura/machinery/pull/1)
+- New, more functional DSL, not relying on Macros so much - [Pull Request](https://github.com/joaomdmoura/machinery/pull/1)
+- Adding support for before and after callbacks - [Pull Request](https://github.com/joaomdmoura/machinery/pull/2)
 
 ## 0.2.0
 - Enabling states and transitions declarations

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ def deps do
 end
 ```
 
-### Declaring States
+## Declaring States
 
 Declare the states you need pasing it as an argment when importing `Machinery`
 on the module that will control your states transitions.
@@ -41,7 +41,27 @@ Machinery expects a `Keyword` as argument with two keys `states` and `transition
 - states: A List of Atoms representing each state.
 - transitions: A List of Maps, including two keys `from` and `to`, `to` might be an Atom or a List of Atoms.
 
-#### Example
+### Example
+
+```elixir
+defmodule YourProject.UserStateMachine do
+  use Machinery,
+    # The first state declared will be considered the intial state
+    states: [:created, :partial, :complete],
+    transitions: %{
+      created: [:partial, :complete],
+      partial: :completed
+    }
+end
+```
+
+## Guard functions
+Create guard conditions by adding signatures of the `guard_transition/2`
+function, pattern matching the desired state you want to guard.
+
+Guard conditions should return a boolean:
+  - `true`: Guard clause will allow the transition.
+  - `false`: Transition won't be allowed.
 
 ```elixir
 defmodule YourProject.UserStateMachine do
@@ -53,20 +73,38 @@ defmodule YourProject.UserStateMachine do
       partial: :completed
     }
 
-  # Create guard conditions by adding signatures of the
-  # guard_transition/2 function, pattern matching the
-  # desired state you want to guard.
-  #
-  # Eg.
-  # guard_transition(unmodified_struct, :next_state)
-  #
-  # Guard conditions should return a boolean:
-  # true: Guard clause will allow the transition
-  # false: Transition won't be allowed
-  #
   def guard_transition(struct, :complete) do
    Map.get(struct, :missing_fields) == false
   end
+end
+```
+
+## Before and After callbacks
+
+You can also use before and after callbacks to handle desired side effects and
+reactions to a specific state transition, the implementation is pretty similar to
+guard functions, you can just declare `before_transition/2` and ``after_transition/2`.
+Before and After callbacks should return the struct being manipulated.
+
+```elixir
+defmodule YourProject.UserStateMachine do
+  use Machinery,
+    # The first state declared will be considered the intial state
+    states: [:created, :partial, :complete],
+    transitions: %{
+      created: [:partial, :complete],
+      partial: :completed
+    }
+
+   def before_transition(struct, :partial) do
+      # ... overall desired side effect
+      struct
+    end
+
+    def after_transition(struct, :completed) do
+      # ... overall desired side effect
+      struct
+    end
 end
 ```
 
@@ -92,4 +130,4 @@ user = Accounts.get_user!(1)
 UserStateMachine.transition_to(user, :partial)
 ```
 
-Guard functions will be checked automatically.
+Guard functions, before and after callbacks will be checked automatically.

--- a/README.md
+++ b/README.md
@@ -11,14 +11,20 @@ Pheonix out of the box.
 It also aims to have (when implemented with Phoenix) an optional build-in GUI
 that will represent each resource's state.
 
-### DISCLAMER
+## DISCLAMER
 
 Machinery is under heavy development, this README does't match the docs for the
-current released version `0.2.0`, you can check the docs on the link bellow.
+current released version `0.2.0`, you can check the docs on the proper released
+[Machinery Docs](https://hexdocs.pm/machinery)
 
-Check proper [Machinery Docs](https://hexdocs.pm/machinery)
+- [Installing](#installing)
+- [Declaring States](#declaring-states)
+- [Changing States](#changing-states)
+- [Guard Functions](#guard-functions)
+- [Before and After Callbacks](#before-and-after-callbacks)
 
-## Installation
+
+## Installing
 
 The package can be installed by adding `machinery` to your list of
 dependencies in `mix.exs`:
@@ -54,6 +60,30 @@ defmodule YourProject.UserStateMachine do
     }
 end
 ```
+
+## Changing States
+
+To transit a struct into another state, you just need to call `Machinery.transition_to/2`
+
+### `Machinery.transition_to/2`
+It takes two arguments:
+
+- struct: The struct you want to transit to another state
+- next_event: An atom representing the next state you want the struct to transition to
+
+```elixir
+Machinery.transition_to(your_struct, :next_state)
+# {:ok, updated_struct}
+```
+
+### Example:
+
+```elixir
+user = Accounts.get_user!(1)
+UserStateMachine.transition_to(user, :partial)
+```
+
+Guard functions, before and after callbacks will be checked automatically.
 
 ## Guard functions
 Create guard conditions by adding signatures of the `guard_transition/2`
@@ -107,27 +137,3 @@ defmodule YourProject.UserStateMachine do
     end
 end
 ```
-
-## Usage
-
-To transit a struct into another state, you just need to call `Machinery.transition_to/2`
-
-### `Machinery.transition_to/2`
-It takes two arguments:
-
-- struct: The struct you want to transit to another state
-- next_event: An atom representing the next state you want the struct to transition to
-
-```elixir
-Machinery.transition_to(your_struct, :next_state)
-# {:ok, updated_struct}
-```
-
-### Example
-
-```elixir
-user = Accounts.get_user!(1)
-UserStateMachine.transition_to(user, :partial)
-```
-
-Guard functions, before and after callbacks will be checked automatically.

--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -87,14 +87,14 @@ defmodule Machinery do
       !Transition.declared_transition?(transitions, current_state, next_state) ->
         {:error, @not_declated_error}
 
-      Transition.guarded_transition?(module, struct, next_state) ->
+      !Transition.guarded_transition?(module, struct, next_state) ->
         {:error, @guarded_error}
 
       true ->
         struct = struct
-          |> Transition.run_before_callbacks(next_state, module)
+          |> Transition.before_callbacks(next_state, module)
           |> Map.put(:state, next_state)
-          |> Transition.run_after_callbacks(next_state, module)
+          |> Transition.after_callbacks(next_state, module)
         {:ok, struct}
     end
   end

--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -7,9 +7,9 @@ defmodule Machinery do
 
   ## Parameters
 
-    - opts: A Keyword including `states` and `transitions`.
-      - states: A List of Atoms representing each state.
-      - transitions: A List of Maps, including two keys `from` and `to`, to might be an Atom or a List of Atoms.
+    - `opts`: A Keyword including `states` and `transitions`.
+      - `states`: A List of Atoms representing each state.
+      - `transitions`: A List of Maps, including two keys `from` and `to`, to might be an Atom or a List of Atoms.
 
   ## Example
     ```
@@ -54,18 +54,19 @@ defmodule Machinery do
   @doc """
   Triggers the transition of a struct to a new state if it passes the
   existing guard clause, also runs any before or after callbacks.
-  It returns a tuple with {:ok, state}, or {:error, "cause"}.
+  It returns a tuple with `{:ok, state}`, or `{:error, "cause"}`.
 
   ## Parameters
 
-    - struct: A Struct based on a module using Machinery.
-    - next_state: Atom of the next state you want to transition to.
+    - `struct`: A Struct based on a module using Machinery.
+    - `next_state`: Atom of the next state you want to transition to.
 
   ## Examples
 
       Machinery.transition_to(%User{state: :partial}, :completed)
       {:ok, %User{state: :completed}}
   """
+  @spec transition_to(struct, atom) :: {:ok, struct} | {:error, String.t}
   def transition_to(struct, next_state) do
     module = struct.__struct__
     initial_state = module._machinery_initial_state()

--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -91,7 +91,10 @@ defmodule Machinery do
         {:error, @guarded_error}
 
       true ->
-        struct = Map.put(struct, :state, next_state)
+        struct = struct
+          |> Transition.run_before_callbacks(next_state, module)
+          |> Map.put(:state, next_state)
+          |> Transition.run_after_callbacks(next_state, module)
         {:ok, struct}
     end
   end

--- a/lib/machinery/transition.ex
+++ b/lib/machinery/transition.ex
@@ -1,0 +1,43 @@
+defmodule Machinery.Transition do
+  @moduledoc """
+  Machinery module responsible for control transitions,
+  guard functions and callbacks (before and after).
+  It's meant to be for internal use only.
+  """
+
+  @doc """
+  Default guard transition fallback to make sure all transitions are permitted
+  unless another existing guard condition exists.
+  """
+  @spec guarded_transition?(module, struct, atom) :: boolean
+  def guarded_transition?(module, struct, next_state) do
+    !module.guard_transition(struct, next_state)
+  rescue
+    error in UndefinedFunctionError -> guard_transition_fallback?(error)
+    error in FunctionClauseError -> guard_transition_fallback?(error)
+  end
+
+  @doc """
+  Function responsible for checking if the transition from a state to another
+  was specifically declared.
+  """
+  @spec declared_transition?(list, atom, atom) :: boolean
+  def declared_transition?(transitions, current_state, next_state) do
+    case Map.fetch(transitions, current_state) do
+      {:ok, [_|_] = declared_states} -> Enum.member?(declared_states, next_state)
+      {:ok, declared_state} -> declared_state == next_state
+      :error -> false
+    end
+  end
+
+  # If the exception passed id related to a specific signature of
+  # guard_transition/2 it will fallback returning true and
+  # allwoing the transition, otherwise it will raise the exception.
+  defp guard_transition_fallback?(error) do
+    if error.function == :guard_transition && error.arity == 2 do
+      false
+    else
+      raise error
+    end
+  end
+end

--- a/lib/machinery/transition.ex
+++ b/lib/machinery/transition.ex
@@ -21,27 +21,41 @@ defmodule Machinery.Transition do
   @doc """
   Default guard transition fallback to make sure all transitions are permitted
   unless another existing guard condition exists.
+  It's meant to be for internal use only.
   """
   @spec guarded_transition?(module, struct, atom) :: boolean
-  def guarded_transition?(module, struct, next_state) do
-    !module.guard_transition(struct, next_state)
-  rescue
-    error in UndefinedFunctionError -> guard_transition_fallback?(error)
-    error in FunctionClauseError -> guard_transition_fallback?(error)
+  def guarded_transition?(module, struct, state) do
+    run_or_fallback(&module.guard_transition/2, &guard_transition_fallback/2, struct, state)
   end
 
-  def run_before_callbacks(struct, state, module) do
-    module.before_transition(struct, state)
-  rescue
-    error in UndefinedFunctionError -> callbacks_fallback(struct, error)
-    error in FunctionClauseError -> callbacks_fallback(struct, error)
+  @doc """
+  Function responsible to run all before_transitions callbacks or
+  fallback to a boilerplate behaviour. It's meant to be for internal use only.
+  """
+  @spec before_callbacks(struct, atom, module) :: struct
+  def before_callbacks(struct, state, module) do
+    run_or_fallback(&module.before_transition/2, &callbacks_fallback/2, struct, state)
   end
 
-  def run_after_callbacks(struct, state, module) do
-    module.after_transition(struct, state)
+  @doc """
+  Function responsible to run all after_transitions callbacks or
+  fallback to a boilerplate behaviour. It's meant to be for internal use only.
+  """
+  @spec after_callbacks(struct, atom, module) :: struct
+  def after_callbacks(struct, state, module) do
+    run_or_fallback(&module.after_transition/2, &callbacks_fallback/2, struct, state)
+  end
+
+  # Private function that receives a function, a callback,
+  # a struct and the related state. It tries to execute the function,
+  # rescue for a couple of specific Exceptions and passes it forward
+  # to the callback, that will re-raise it if not related to
+  # guard_transition nor before | after call backs
+  defp run_or_fallback(func, callback, struct, state) do
+    func.(struct, state)
   rescue
-    error in UndefinedFunctionError -> callbacks_fallback(struct, error)
-    error in FunctionClauseError -> callbacks_fallback(struct, error)
+    error in UndefinedFunctionError -> callback.(struct, error)
+    error in FunctionClauseError -> callback.(struct, error)
   end
 
   defp callbacks_fallback(struct, error) do
@@ -55,9 +69,9 @@ defmodule Machinery.Transition do
   # If the exception passed id related to a specific signature of
   # guard_transition/2 it will fallback returning true and
   # allwoing the transition, otherwise it will raise the exception.
-  defp guard_transition_fallback?(error) do
+  defp guard_transition_fallback(_struct, error) do
     if error.function == :guard_transition && error.arity == 2 do
-      false
+      true
     else
       raise error
     end

--- a/lib/machinery/transition.ex
+++ b/lib/machinery/transition.ex
@@ -2,12 +2,13 @@ defmodule Machinery.Transition do
   @moduledoc """
   Machinery module responsible for control transitions,
   guard functions and callbacks (before and after).
-  It's meant to be for internal use only.
+  This is meant to be for internal use only.
   """
 
   @doc """
   Function responsible for checking if the transition from a state to another
   was specifically declared.
+  This is meant to be for internal use only.
   """
   @spec declared_transition?(list, atom, atom) :: boolean
   def declared_transition?(transitions, current_state, next_state) do
@@ -21,7 +22,7 @@ defmodule Machinery.Transition do
   @doc """
   Default guard transition fallback to make sure all transitions are permitted
   unless another existing guard condition exists.
-  It's meant to be for internal use only.
+  This is meant to be for internal use only.
   """
   @spec guarded_transition?(module, struct, atom) :: boolean
   def guarded_transition?(module, struct, state) do
@@ -30,7 +31,8 @@ defmodule Machinery.Transition do
 
   @doc """
   Function responsible to run all before_transitions callbacks or
-  fallback to a boilerplate behaviour. It's meant to be for internal use only.
+  fallback to a boilerplate behaviour.
+  This is meant to be for internal use only.
   """
   @spec before_callbacks(struct, atom, module) :: struct
   def before_callbacks(struct, state, module) do
@@ -39,7 +41,8 @@ defmodule Machinery.Transition do
 
   @doc """
   Function responsible to run all after_transitions callbacks or
-  fallback to a boilerplate behaviour. It's meant to be for internal use only.
+  fallback to a boilerplate behaviour.
+  This is meant to be for internal use only.
   """
   @spec after_callbacks(struct, atom, module) :: struct
   def after_callbacks(struct, state, module) do

--- a/test/machinery/transition_test.exs
+++ b/test/machinery/transition_test.exs
@@ -1,0 +1,16 @@
+defmodule MachineryTest.TransitionTest do
+  use ExUnit.Case
+  doctest Machinery.Transition
+  alias Machinery.Transition
+
+  test "declared_transition?/3 based on a map of transitions, current and next state" do
+    transitions = %{
+      created: [:partial, :completed],
+      partial: :completed
+    }
+    assert Transition.declared_transition?(transitions, :created, :partial)
+    assert Transition.declared_transition?(transitions, :created, :completed)
+    assert Transition.declared_transition?(transitions, :partial, :completed)
+    refute Transition.declared_transition?(transitions, :partial, :created)
+  end
+end

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -53,13 +53,13 @@ defmodule MachineryTest do
     assert {:ok, %TestModuleWithGuard{state: :partial}} = Machinery.transition_to(created_struct, :partial)
     assert {:ok, %TestModuleWithGuard{state: :completed, missing_fields: false}} = Machinery.transition_to(created_struct, :completed)
     assert {:ok, %TestModuleWithGuard{state: :completed, missing_fields: false}} = Machinery.transition_to(partial_struct, :completed)
-    assert {:error, "Transition to this state isn't allowed"} = Machinery.transition_to(stateless_struct, :created)
-    assert {:error, "Transition to this state isn't allowed"} = Machinery.transition_to(completed_struct, :created)
+    assert {:error, "Transition to this state isn't declared."} = Machinery.transition_to(stateless_struct, :created)
+    assert {:error, "Transition to this state isn't declared."} = Machinery.transition_to(completed_struct, :created)
   end
 
   test "Guard functions should be executed before moving the resource to the next state" do
     struct = %TestModuleWithGuard{state: :created, missing_fields: true}
-    assert {:error, "Transition not completed, blocked by guard function"} = Machinery.transition_to(struct, :completed)
+    assert {:error, "Transition not completed, blocked by guard function."} = Machinery.transition_to(struct, :completed)
   end
 
   test "Guard functions should allow or block transitions" do
@@ -67,7 +67,7 @@ defmodule MachineryTest do
     blocked_struct = %TestModuleWithGuard{state: :created, missing_fields: true}
 
     assert {:ok, %TestModuleWithGuard{state: :completed, missing_fields: false}} = Machinery.transition_to(allowed_struct, :completed)
-    assert {:error, "Transition not completed, blocked by guard function"} = Machinery.transition_to(blocked_struct, :completed)
+    assert {:error, "Transition not completed, blocked by guard function."} = Machinery.transition_to(blocked_struct, :completed)
   end
 
   test "The first declared state should be considered the initial one" do


### PR DESCRIPTION
This PR adds the initial tests and implementation for before and after
callbacks. It follows a similar implementation to the guard fucntions,
relying on rescuing the specific exceptions.

There is also some refactoring and improvements no the docs.