### PR TITLE
Adding support to automatic persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP Version
 - Improving docs
 - Updating DSl to Decouple Machinery from the struct itself - [Pull Request](https://github.com/joaomdmoura/machinery/pull/10)
+- Adding support for automatic persistence - [Pull Request](https://github.com/joaomdmoura/machinery/pull/11)
 
 ## 0.4.1
 - Updating wrong docs and README - [Pull Request](https://github.com/joaomdmoura/machinery/pull/5)

--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -96,7 +96,7 @@ defmodule Machinery do
     # first declared state on the struct model.
     current_state = case Map.get(struct, :state) do
       nil -> initial_state
-      current_state -> current_state
+      current_state -> String.to_atom(current_state)
     end
 
     # Checking declared transitions and guard functions before
@@ -111,7 +111,7 @@ defmodule Machinery do
       true ->
         struct = struct
           |> Transition.before_callbacks(next_state, state_machine_module)
-          |> Map.put(:state, next_state)
+          |> Transition.persist_struct(Atom.to_string(next_state), state_machine_module)
           |> Transition.after_callbacks(next_state, state_machine_module)
         {:ok, struct}
     end

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -50,6 +50,16 @@ defmodule MachineryTest do
     def after_transition(struct, :completed) do
       Map.put(struct, :missing_fields, false)
     end
+
+    def persist(struct, next_state) do
+      # Code to simulate and force an exception inside a
+      # guard function.
+      if Map.get(struct, :force_exception) do
+        Machinery.non_existing_function_should_raise_error()
+      end
+
+      Map.put(struct, :state, next_state)
+    end
   end
 
   test "All internal functions should be injected into AST" do
@@ -59,43 +69,43 @@ defmodule MachineryTest do
   end
 
   test "Only the declared transitions should be valid" do
-    created_struct = %TestStruct{state: :created, missing_fields: false}
-    partial_struct = %TestStruct{state: :partial, missing_fields: false}
+    created_struct = %TestStruct{state: "created", missing_fields: false}
+    partial_struct = %TestStruct{state: "partial", missing_fields: false}
     stateless_struct = %TestStruct{}
-    completed_struct = %TestStruct{state: :completed}
+    completed_struct = %TestStruct{state: "completed"}
 
-    assert {:ok, %TestStruct{state: :partial}} = Machinery.transition_to(created_struct, TestStateMachine, :partial)
-    assert {:ok, %TestStruct{state: :completed, missing_fields: false}} = Machinery.transition_to(created_struct, TestStateMachine, :completed)
-    assert {:ok, %TestStruct{state: :completed, missing_fields: false}} = Machinery.transition_to(partial_struct, TestStateMachine, :completed)
+    assert {:ok, %TestStruct{state: "partial"}} = Machinery.transition_to(created_struct, TestStateMachine, :partial)
+    assert {:ok, %TestStruct{state: "completed", missing_fields: false}} = Machinery.transition_to(created_struct, TestStateMachine, :completed)
+    assert {:ok, %TestStruct{state: "completed", missing_fields: false}} = Machinery.transition_to(partial_struct, TestStateMachine, :completed)
     assert {:error, "Transition to this state isn't declared."} = Machinery.transition_to(stateless_struct, TestStateMachine, :created)
     assert {:error, "Transition to this state isn't declared."} = Machinery.transition_to(completed_struct, TestStateMachine, :created)
   end
 
   test "Guard functions should be executed before moving the resource to the next state" do
-    struct = %TestStruct{state: :created, missing_fields: true}
+    struct = %TestStruct{state: "created", missing_fields: true}
     assert {:error, "Transition not completed, blocked by guard function."} = Machinery.transition_to(struct, TestStateMachineWithGuard, :completed)
   end
 
   test "Guard functions should allow or block transitions" do
-    allowed_struct = %TestStruct{state: :created, missing_fields: false}
-    blocked_struct = %TestStruct{state: :created, missing_fields: true}
+    allowed_struct = %TestStruct{state: "created", missing_fields: false}
+    blocked_struct = %TestStruct{state: "created", missing_fields: true}
 
-    assert {:ok, %TestStruct{state: :completed, missing_fields: false}} = Machinery.transition_to(allowed_struct, TestStateMachineWithGuard, :completed)
+    assert {:ok, %TestStruct{state: "completed", missing_fields: false}} = Machinery.transition_to(allowed_struct, TestStateMachineWithGuard, :completed)
     assert {:error, "Transition not completed, blocked by guard function."} = Machinery.transition_to(blocked_struct, TestStateMachineWithGuard, :completed)
   end
 
   test "The first declared state should be considered the initial one" do
     stateless_struct = %TestStruct{}
-    assert {:ok, %TestStruct{state: :partial}} = Machinery.transition_to(stateless_struct, TestStateMachine, :partial)
+    assert {:ok, %TestStruct{state: "partial"}} = Machinery.transition_to(stateless_struct, TestStateMachine, :partial)
   end
 
   test "Modules without guard conditions should allow transitions by default" do
-    struct = %TestStruct{state: :created}
-    assert {:ok, %TestStruct{state: :completed}} = Machinery.transition_to(struct, TestStateMachine, :completed)
+    struct = %TestStruct{state: "created"}
+    assert {:ok, %TestStruct{state: "completed"}} = Machinery.transition_to(struct, TestStateMachine, :completed)
   end
 
   test "Implict rescue on the guard clause internals should raise any other excepetion not strictly related to missing guard_tranistion/2 existence" do
-    wrong_struct = %TestStruct{state: :created, force_exception: true}
+    wrong_struct = %TestStruct{state: "created", force_exception: true}
     assert_raise UndefinedFunctionError, fn() ->
       Machinery.transition_to(wrong_struct, TestStateMachineWithGuard, :completed)
     end
@@ -113,9 +123,21 @@ defmodule MachineryTest do
   end
 
   test "Implict rescue on the callbacks internals should raise any other excepetion not strictly related to missing callbacks_fallback/2 existence" do
-    wrong_struct = %TestStruct{state: :created, force_exception: true}
+    wrong_struct = %TestStruct{state: "created", force_exception: true}
     assert_raise UndefinedFunctionError, fn() ->
       Machinery.transition_to(wrong_struct, TestStateMachine, :partial)
+    end
+  end
+
+  test "Persist function should be called after the transition" do
+    struct = %TestStruct{state: "partial"}
+    assert {:ok, _} = Machinery.transition_to(struct, TestStateMachine, :completed)
+  end
+
+  test "Persist function should still reaise errors if not related to the existence of persist/1 method" do
+    wrong_struct = %TestStruct{state: "created", force_exception: true}
+    assert_raise UndefinedFunctionError, fn() ->
+      Machinery.transition_to(wrong_struct, TestStateMachine, :completed)
     end
   end
 end


### PR DESCRIPTION
This enable users to have automatic persistence following a similar
behaviour of the onw implemented on the callbacks and guard functions,
if Machinery founds a `persist/2` function on the State Machine module
it will call it instead of updating the struct itself.

Relates to issue: https://github.com/joaomdmoura/machinery/issues/3