### PR TITLE
Enabling users to overwrite the desired state on Machinery Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP Version
 - Adding a default config desabling the Machinery Dashboard
 - Making the Machinery Dashbaord bigger
+- Enabling users to overwrite the desired state on Machinery Dashboard - [Pull Request](https://github.com/joaomdmoura/machinery/pull/21)
 
 ## 0.8.2
 - Requiring a previous version of phoenix_html to enable older applications to use Machinery.

--- a/README.md
+++ b/README.md
@@ -176,12 +176,14 @@ You will also need to add some config to your `config.exs`:
 - `repo`: your app's repo module.
 - `model`: the model that will hold the state.
 - `module`: the machinery module where you have the declared states.
+- *(Optional)* `dashboard_states`: A list of the states you want on the dashboard.
 
 ```elixir
 config :machinery,
   interface: true,
   repo: YourApp.Repo,
   model: YourApp.User,
+  # Optinal: dashboard_states: ["created", "partial"],
   module: YourApp.UserStateMachine
 ```
 

--- a/lib/web/controllers/resource_controller.ex
+++ b/lib/web/controllers/resource_controller.ex
@@ -17,8 +17,12 @@ defmodule Machinery.ResourceController do
     model = conn.assigns.model
     machinery_module = conn.assigns.module
 
-    states = machinery_module._machinery_states()
-    states_and_resources = Enum.map(states, fn(state) ->
+    desired_states = case Application.get_env(:machinery, :dashboard_states) do
+      nil -> machinery_module._machinery_states()
+      states -> states
+    end
+
+    states_and_resources = Enum.map(desired_states, fn(state) ->
       resources = get_resources_for_state(repo, model, state)
       %{name: state, resources: resources}
     end)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -32,7 +32,7 @@ defmodule MachineryTest.Helper do
     Process.exit(supervisor_pid, :kill)
     receive do
       _ ->
-        :timer.sleep(1000)
+        :timer.sleep(1500)
         Application.start(:machinery)
     end
   end

--- a/test/web/controllers/resource_controller_test.exs
+++ b/test/web/controllers/resource_controller_test.exs
@@ -19,7 +19,7 @@ defmodule MachineryTest.ResourceControllerTest do
   @tag :capture_log
   test "index/2 should assign a list with the resources in each state" do
     conn = Machinery.Plug.call(conn(:get, "/"), "/")
-    resoruces_for_each_state = Enum.map(conn.assigns.states, fn(_x) ->
+    resoruces_for_each_state = Enum.map(TestStateMachine._machinery_states(), fn(_x) ->
       TestRepo.all(nil)
     end)
     assert resoruces_for_each_state == Enum.map(conn.assigns.states, &(&1.resources))
@@ -53,6 +53,17 @@ defmodule MachineryTest.ResourceControllerTest do
     page = 2
     conn = Machinery.Plug.call(conn(:get, "/machinery/api/#{state}/resources/#{page}"), [])
     assert Poison.decode!(conn.resp_body) == []
+  end
+
+  @tag :capture_log
+  test "index/2 should overwrite the desired states based on a machinery config" do
+    state = List.first(TestStateMachine._machinery_states())
+    Application.put_env(:machinery, :dashboard_states, [state])
+    conn = Machinery.Plug.call(conn(:get, "/"), "/")
+    resoruces_for_each_state = Enum.map([state], fn(_x) ->
+      TestRepo.all(nil)
+    end)
+    assert resoruces_for_each_state == Enum.map(conn.assigns.states, &(&1.resources))
   end
 
   defp stringify_keys(nil), do: nil

--- a/test/web/controllers/resource_controller_test.exs
+++ b/test/web/controllers/resource_controller_test.exs
@@ -18,6 +18,7 @@ defmodule MachineryTest.ResourceControllerTest do
 
   @tag :capture_log
   test "index/2 should assign a list with the resources in each state" do
+    Application.put_env(:machinery, :dashboard_states, nil)
     conn = Machinery.Plug.call(conn(:get, "/"), "/")
     resoruces_for_each_state = Enum.map(TestStateMachine._machinery_states(), fn(_x) ->
       TestRepo.all(nil)

--- a/test/web/controllers/resource_controller_test.exs
+++ b/test/web/controllers/resource_controller_test.exs
@@ -12,6 +12,7 @@ defmodule MachineryTest.ResourceControllerTest do
 
   @tag :capture_log
   test "index/2 should assign a state map to the conn with all states declared" do
+    Application.put_env(:machinery, :dashboard_states, nil)
     conn = Machinery.Plug.call(conn(:get, "/"), "/")
     assert TestStateMachine._machinery_states() == Enum.map(conn.assigns.states, &(&1.name))
   end


### PR DESCRIPTION
Relates to: https://github.com/joaomdmoura/machinery/issues/18

That helps people to have as many as states as they need without compromising
the Dashbord, still being able to expose that to other stackholders interested
on the state machine.
That also helps people to have "archvived" states and opt-out from having those
on the Dashboard.