### PR TITLE
Better treating the JSON return for the Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## WIP Version
+- Better treating the JSON return for the Dashboard - [Pull Request](https://github.com/joaomdmoura/machinery/pull/27)
 
 ## 0.12.0
 - Adding new toogle all btn and auto closing alerts - [Pull Request](https://github.com/joaomdmoura/machinery/pull/24)

--- a/lib/web/controllers/resource_controller.ex
+++ b/lib/web/controllers/resource_controller.ex
@@ -10,7 +10,10 @@ defmodule Machinery.ResourceController do
     machinery_module = conn.assigns.module
 
     struct = repo.get!(model, id)
-    {transition, content} = Machinery.transition_to(struct, machinery_module, state)
+    {transition, content} = case Machinery.transition_to(struct, machinery_module, state) do
+      {:ok, struct} -> {:ok, struct.id}
+      {:error, message} -> {:error, message}
+    end
 
     json(conn, [transition, content])
   end

--- a/test/web/controllers/resource_controller_test.exs
+++ b/test/web/controllers/resource_controller_test.exs
@@ -71,8 +71,9 @@ defmodule MachineryTest.ResourceControllerTest do
   @tag :capture_log
   test "index/2 api should enable to transition states" do
     updated_stuct = %{"state" => "partial", "missing_fields" => true, "id" => "1"}
+    id = Map.get(updated_stuct, "id")
     conn = Machinery.Plug.call(conn(:post, "/machinery/api/resources/#{updated_stuct["id"]}", state: "partial"), [])
-    assert Poison.decode!(conn.resp_body) == ["ok", updated_stuct]
+    assert Poison.decode!(conn.resp_body) == ["ok", id]
   end
 
   defp stringify_keys(nil), do: nil


### PR DESCRIPTION
This will prevent bad enconding errors caused by any struct being returned