### PR TITLE
Adding support for wildcard transitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## WIP Version
+- Adding support for wildcard transitions - [Pull Request](https://github.com/joaomdmoura/machinery/pull/32)
 
 ## 0.13.0
 - Adding basic auth to Machinery Dashboard - [Pull Request](https://github.com/joaomdmoura/machinery/pull/30)

--- a/README.md
+++ b/README.md
@@ -84,13 +84,17 @@ defmodule YourProject.UserStateMachine do
   use Machinery,
     # The first state declared will be considered
     # the initial state
-    states: ["created", "partial", "complete"],
+    states: ["created", "partial", "complete", "canceled"],
     transitions: %{
       "created" =>  ["partial", "complete"],
-      "partial" => "completed"
+      "partial" => "completed",
+      "*" => "canceled
     }
 end
 ```
+
+As you might notice you can use wildcards `"*"` to declare a transition that
+can happen from any state to a specific one.
 
 ## Changing States
 

--- a/test/machinery/transition_test.exs
+++ b/test/machinery/transition_test.exs
@@ -5,12 +5,22 @@ defmodule MachineryTest.TransitionTest do
 
   test "declared_transition?/3 based on a map of transitions, current and next state" do
     transitions = %{
-      created: [:partial, :completed],
-      partial: :completed
+      "created" => ["partial", "completed"],
+      "partial" => "completed"
     }
-    assert Transition.declared_transition?(transitions, :created, :partial)
-    assert Transition.declared_transition?(transitions, :created, :completed)
-    assert Transition.declared_transition?(transitions, :partial, :completed)
-    refute Transition.declared_transition?(transitions, :partial, :created)
+    assert Transition.declared_transition?(transitions, "created", "partial")
+    assert Transition.declared_transition?(transitions, "created", "completed")
+    assert Transition.declared_transition?(transitions, "partial", "completed")
+    refute Transition.declared_transition?(transitions, "partial", "created")
+  end
+
+  test "declared_transition?/3 for a declared transition that allows transition for any state" do
+    transitions = %{
+      "created" => "completed",
+      "*" =>"canceled"
+    }
+    assert Transition.declared_transition?(transitions, "created", "completed")
+    assert Transition.declared_transition?(transitions, "created", "canceled")
+    assert Transition.declared_transition?(transitions, "completed", "canceled")
   end
 end

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -26,6 +26,17 @@ defmodule MachineryTest do
     assert {:error, "Transition to this state isn't declared."} = Machinery.transition_to(completed_struct, TestStateMachine, "created")
   end
 
+  test "Wildcard transitions should be valid" do
+    created_struct = %TestStruct{state: "created", missing_fields: false}
+    partial_struct = %TestStruct{state: "partial", missing_fields: false}
+    completed_struct = %TestStruct{state: "completed"}
+
+    assert {:ok, %TestStruct{state: "canceled", missing_fields: false}} = Machinery.transition_to(created_struct, TestStateMachine, "canceled")
+    assert {:ok, %TestStruct{state: "canceled", missing_fields: false}} = Machinery.transition_to(partial_struct, TestStateMachine, "canceled")
+    assert {:ok, %TestStruct{state: "canceled"}} = Machinery.transition_to(completed_struct, TestStateMachine, "canceled")
+  end
+
+
   test "Guard functions should be executed before moving the resource to the next state" do
     struct = %TestStruct{state: "created", missing_fields: true}
     assert {:error, "Transition not completed, blocked by guard function."} = Machinery.transition_to(struct, TestStateMachineWithGuard, "completed")

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -36,7 +36,6 @@ defmodule MachineryTest do
     assert {:ok, %TestStruct{state: "canceled"}} = Machinery.transition_to(completed_struct, TestStateMachine, "canceled")
   end
 
-
   test "Guard functions should be executed before moving the resource to the next state" do
     struct = %TestStruct{state: "created", missing_fields: true}
     assert {:error, "Transition not completed, blocked by guard function."} = Machinery.transition_to(struct, TestStateMachineWithGuard, "completed")

--- a/test/support/test_state_machine.exs
+++ b/test/support/test_state_machine.exs
@@ -1,9 +1,10 @@
 defmodule MachineryTest.TestStateMachine do
   use Machinery,
-    states: ["created", "partial", "completed"],
+    states: ["created", "partial", "completed", "canceled"],
     transitions: %{
       "created" => ["partial", "completed"],
-      "partial" => "completed"
+      "partial" => "completed",
+      "*" => "canceled"
     }
 
   def before_transition(struct, "partial") do


### PR DESCRIPTION
Related to #17 

This feature will enable people to add transitions that can be
made from any state, pretty useful for use cases where a 'canceled'
state might exist, you can easily declare it as a valid transition from
any state using a wildcard "*" => "next_state"