### PR TITLE
Adding support for logging transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## WIP Version
+- Adding support for transitions logging - [Pull Request](https://github.com/joaomdmoura/machinery/pull/33)
 
 ## 0.14.0
 - Adding support for wildcard transitions - [Pull Request](https://github.com/joaomdmoura/machinery/pull/32)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Don't forget to check the [Machinery Docs](https://hexdocs.pm/machinery)
 - [Declaring States](#declaring-states)
 - [Changing States](#changing-states)
 - [Persist State](#persist-state)
+- [Logging Transitions](#logging-transitions)
 - [Enable Dashboard with Phoenix](#enable-dashboard-wiht-phoenix)
 - [Guard Functions](#guard-functions)
 - [Before and After Callbacks](#before-and-after-callbacks)
@@ -147,6 +148,36 @@ defmodule YourProject.UserStateMachine do
     # Updating a user on the database with the new state.
     {:ok, user} = Accounts.update_user(struct, %{state: next_state})
     user
+  end
+end
+```
+
+## Logging Transitions
+To log/persist the transitions itself Machinery provides a callback
+`log_transitions/2` that will be called on every transition.
+
+It will receive the unchanged `struct` as the first argument and a `string` of
+the next state as the second one, after every state transition.
+This function will be called between the before and after transition callbacks
+and after the persist function.
+
+**`log_transition/2` should always return the updated struct.**
+
+### Example:
+
+```elixir
+defmodule YourProject.UserStateMachine do
+  alias YourProject.Accounts
+
+  use Machinery,
+    states: ["created", "complete"],
+    transitions: %{"created" => "complete"}
+
+  def log_transition(struct, _next_state) do
+    # Log transition here, save on the DB or whatever.
+    # ...
+    # Return the struct.
+    struct
   end
 end
 ```

--- a/lib/machinery/transitions.ex
+++ b/lib/machinery/transitions.ex
@@ -41,6 +41,7 @@ defmodule Machinery.Transitions do
         struct = struct
           |> Transition.before_callbacks(next_state, state_machine_module)
           |> Transition.persist_struct(next_state, state_machine_module)
+          |> Transition.log_transition(next_state, state_machine_module)
           |> Transition.after_callbacks(next_state, state_machine_module)
         {:ok, struct}
     end

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -99,6 +99,19 @@ defmodule MachineryTest do
     end
   end
 
+  test "Transition log function should be called after the transition" do
+    struct = %TestStruct{state: "created"}
+    assert {:ok, _} = Machinery.transition_to(struct, TestStateMachineWithGuard, "partial")
+  end
+
+  @tag :capture_log
+  test "Transition log function should still reaise errors if not related to the existence of persist/1 method" do
+    wrong_struct = %TestStruct{state: "created", force_exception: true}
+    assert_raise UndefinedFunctionError, fn() ->
+      Machinery.transition_to(wrong_struct, TestStateMachineWithGuard, "partial")
+    end
+  end
+
   @tag :capture_log
   test "Machinery.Transitions GenServer should be started under the Machinery.Supervisor" do
     transitions_pid = Process.whereis(Machinery.Transitions)

--- a/test/support/test_state_machine_with_guard.exs
+++ b/test/support/test_state_machine_with_guard.exs
@@ -15,4 +15,13 @@ defmodule MachineryTest.TestStateMachineWithGuard do
 
     Map.get(struct, :missing_fields) == false
   end
+
+  def log_transition(struct, _next_state) do
+    # Log transition here
+    if Map.get(struct, :force_exception) do
+      Machinery.non_existing_function_should_raise_error()
+    end
+
+    struct
+  end
 end


### PR DESCRIPTION
This is related to https://github.com/joaomdmoura/machinery/issues/13
This adds the support for a callback that has as its only purposes logging the transitions from every state.
