### PR TITLE
Allow field name customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ def deps do
 end
 ```
 
-Create a field `state` for the module you want to have a state machine,
-make sure you have declared it as part of you `defstruct`, or if it
-is a Phoenix model make sure you add it to the `schema`, as a `string`,  and
-to the `changeset/2`:
+Create a field `state` (or a name of your choice to be defined later) for the
+module you want to have a state machine, make sure you have declared it as part
+of you `defstruct`, or if it is a Phoenix model make sure you add it to the `schema`,
+as a `string`,  and to the `changeset/2`:
 
 ```elixir
 defmodule YourProject.User do
@@ -72,8 +72,9 @@ It's strongly recommended that you create a new module for your State Machine
 logic. So let's say you want to add it to your `User` model, you should create a
 `UserStateMachine` module to hold your State Machine logic.
 
-Machinery expects a `Keyword` as argument with two keys `states` and `transitions`.
+Machinery expects a `Keyword` as argument with the keys `field`, `states` and `transitions`.
 
+- `field`: An atom of your state field name (defaults to `state`)
 - `states`: A List of Strings representing each state.
 - `transitions`: A Map for each state and it allowed next state(s).
 
@@ -84,6 +85,7 @@ defmodule YourProject.UserStateMachine do
   use Machinery,
     # The first state declared will be considered
     # the initial state
+    field: :custom_state_name,
     states: ["created", "partial", "complete", "canceled"],
     transitions: %{
       "created" =>  ["partial", "complete"],

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -3,8 +3,8 @@ defmodule MachineryTest do
   doctest Machinery
 
   alias MachineryTest.Helper
-  alias MachineryTest.TestStruct
   alias MachineryTest.TestDefaultFieldStruct
+  alias MachineryTest.TestStruct
   alias MachineryTest.TestStateMachine
   alias MachineryTest.TestStateMachineWithGuard
   alias MachineryTest.TestStateMachineDefaultField

--- a/test/support/test_default_field_struct.exs
+++ b/test/support/test_default_field_struct.exs
@@ -1,0 +1,14 @@
+defmodule MachineryTest.TestDefaultFieldStruct do
+  import Ecto.Changeset
+  use Ecto.Schema
+
+  schema "test_default_field_structs" do
+    field(:state, :string)
+    timestamps()
+  end
+
+  @doc false
+  def changeset(test_struct, attrs) do
+    cast(test_struct, attrs, [:state])
+  end
+end

--- a/test/support/test_state_machine.exs
+++ b/test/support/test_state_machine.exs
@@ -1,5 +1,6 @@
 defmodule MachineryTest.TestStateMachine do
   use Machinery,
+    field: :my_state,
     states: ["created", "partial", "completed", "canceled"],
     transitions: %{
       "created" => ["partial", "completed"],
@@ -28,6 +29,6 @@ defmodule MachineryTest.TestStateMachine do
       Machinery.non_existing_function_should_raise_error()
     end
 
-    Map.put(struct, :state, next_state)
+    Map.put(struct, :my_state, next_state)
   end
 end

--- a/test/support/test_state_machine_default_field.exs
+++ b/test/support/test_state_machine_default_field.exs
@@ -1,0 +1,7 @@
+defmodule MachineryTest.TestStateMachineDefaultField do
+  use Machinery,
+    states: ["created", "canceled"],
+    transitions: %{
+      "*" => "canceled"
+    }
+end

--- a/test/support/test_state_machine_with_guard.exs
+++ b/test/support/test_state_machine_with_guard.exs
@@ -1,5 +1,6 @@
 defmodule MachineryTest.TestStateMachineWithGuard do
   use Machinery,
+    field: :my_state,
     states: ["created", "partial", "completed"],
     transitions: %{
       "created" => ["partial", "completed"],

--- a/test/support/test_struct.exs
+++ b/test/support/test_struct.exs
@@ -3,7 +3,7 @@ defmodule MachineryTest.TestStruct do
   use Ecto.Schema
 
   schema "test_structs" do
-    field :state, :string
+    field :my_state, :string
     field :missing_fields, :boolean
     field :force_exception, :boolean
     timestamps()
@@ -11,6 +11,6 @@ defmodule MachineryTest.TestStruct do
 
   @doc false
   def changeset(test_struct, attrs) do
-    cast(test_struct, attrs, [:state, :missing_fields, :force_exception])
+    cast(test_struct, attrs, [:my_state, :missing_fields, :force_exception])
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,8 +2,10 @@ ExUnit.start()
 
 # Load support modules
 Code.load_file("test/support/test_struct.exs")
+Code.load_file("test/support/test_default_field_struct.exs")
 Code.load_file("test/support/test_state_machine.exs")
 Code.load_file("test/support/test_state_machine_with_guard.exs")
+Code.load_file("test/support/test_state_machine_default_field.exs")
 Code.load_file("test/support/test_repo.exs")
 
 defmodule MachineryTest.Helper do
@@ -19,9 +21,11 @@ defmodule MachineryTest.Helper do
     Application.put_env(:machinery, :model, TestStruct)
     Application.put_env(:machinery, :repo, TestRepo)
     Application.put_env(:machinery, :interface, enable)
-    capture_log fn ->
+
+    capture_log(fn ->
       restart_machinery()
-    end
+    end)
+
     :ok
   end
 
@@ -30,6 +34,7 @@ defmodule MachineryTest.Helper do
     supervisor_pid = Process.whereis(Machinery.Supervisor)
     Process.monitor(supervisor_pid)
     Process.exit(supervisor_pid, :kill)
+
     receive do
       _ ->
         :timer.sleep(1500)


### PR DESCRIPTION
Addresses #41 
- Use `state` as a default field name
- Enable field name customization

The "multiple state machines" hinted in the issue is trickier, so I'll leave it for another opportunity.