### PR TITLE
delegate json_decoder config to phoenix

### DIFF
--- a/lib/machinery/endpoint.ex
+++ b/lib/machinery/endpoint.ex
@@ -16,7 +16,7 @@ defmodule Machinery.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Poison,
+    json_decoder: Application.get_env(:phoenix, :json_library, Poison),
     length: 500_000_000
 
   auth_options = Application.get_env(:machinery, :authorization)


### PR DESCRIPTION
This change allows Jason to be configured instead of Poison. Phoenix 1.4 has the same [json_library config](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix.ex#L70). When this library requires phoenix `~> 1.4` it'd be ideal to switch to that.

Related to: https://github.com/joaomdmoura/machinery/issues/40, https://github.com/joaomdmoura/machinery/issues/46
