### PR TITLE
Fixes #39: Adding optional `basic_auth` dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,8 @@ defmodule Machinery.Mixfile do
       {:cowboy, "~> 1.0"},
       {:excoveralls, "~> 0.7", only: :test},
       {:ecto, "~> 3.0"},
-      {:ex_doc, "~> 0.19", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.19", only: :dev, runtime: false},
+      {:basic_auth, "~> 2.2.3", optional: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "basic_auth": {:hex, :basic_auth, "2.2.4", "d8c748237870dd1df3bc5c0f1ab4f1fad6270c75472d7e62b19302ec59e92a79", [:mix], [{:plug, "~> 0.14 or ~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},


### PR DESCRIPTION
This is in reference to https://github.com/joaomdmoura/machinery/issues/39

The goal of this is to make the `basic_auth` dependency overtly declared to ensure there's no weird dependency shenanigans.

Moreover, it is declared as `:optional` (more info can be found in the above linked ticket into how the optional flag works).

cc: @joaomdmoura 

If there's anything needing changing, lemme know.