### PR TITLE
Fixing flaky tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/joaomdmoura/machinery.svg?branch=master)](https://travis-ci.org/joaomdmoura/machinery)
 [![Ebert](https://ebertapp.io/github/joaomdmoura/machinery.svg)](https://ebertapp.io/github/joaomdmoura/machinery)
+[![Coverage Status](https://coveralls.io/repos/github/joaomdmoura/machinery/badge.svg?branch=master)](https://coveralls.io/github/joaomdmoura/machinery?branch=master)
 
 ![Machinery](https://github.com/joaomdmoura/machinery/blob/master/logo.png)
 

--- a/lib/machinery/transition.ex
+++ b/lib/machinery/transition.ex
@@ -143,7 +143,7 @@ defmodule Machinery.Transition do
     end
   end
 
-  # If the exception passed id related to a specific signature of
+  # If the exception passed is related to a specific signature of
   # guard_transition/2 it will fallback returning true and
   # allwoing the transition, otherwise it will raise the exception.
   defp guard_transition_fallback(_struct, _state, error, _field) do

--- a/lib/machinery/transitions.ex
+++ b/lib/machinery/transitions.ex
@@ -23,10 +23,11 @@ defmodule Machinery.Transitions do
   def handle_call({:run, struct, state_machine_module, next_state}, _from, states) do
     initial_state = state_machine_module._machinery_initial_state()
     transitions = state_machine_module._machinery_transitions()
+    state_field = state_machine_module._field()
 
     # Getting current state of the struct or falling back to the
     # first declared state on the struct model.
-    current_state = case Map.get(struct, :state) do
+    current_state = case Map.get(struct, state_field) do
       nil -> initial_state
       current_state -> current_state
     end

--- a/test/machinery/plug_test.exs
+++ b/test/machinery/plug_test.exs
@@ -4,7 +4,7 @@ defmodule MachineryTest.PlugTest do
   alias MachineryTest.Helper
 
   setup_all do
-    Helper.mahcinery_interface()
+    Helper.machinery_interface()
   end
 
   @tag :capture_log
@@ -14,7 +14,7 @@ defmodule MachineryTest.PlugTest do
   end
 
   @tag :capture_log
-  test "Machinery.Plug should send the request to Mahcinery.PageControlller the if `interface` is set as true" do
+  test "Machinery.Plug should send the request to Machinery.ResourceControlller the if `interface` is set as true" do
     conn = Machinery.Plug.call(conn(:get, "/"), "/")
     assert conn.state == :sent
     assert conn.status == 200
@@ -22,7 +22,7 @@ defmodule MachineryTest.PlugTest do
   end
 
   @tag :capture_log
-  test "Machinery.Plug shoudl fall back to its default path defined as `/machinery` if none is provided" do
+  test "Machinery.Plug should fall back to its default path defined as `/machinery` if none is provided" do
     conn = Machinery.Plug.call(conn(:get, "/machinery"), [])
     assert conn.state == :sent
     assert conn.status == 200

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -9,6 +9,10 @@ defmodule MachineryTest do
   alias MachineryTest.TestStateMachineWithGuard
   alias MachineryTest.TestStateMachineDefaultField
 
+  setup do
+    Helper.machinery_interface()
+  end
+
   test "All internal functions should be injected into AST" do
     assert :erlang.function_exported(TestStateMachine, :_machinery_initial_state, 0)
     assert :erlang.function_exported(TestStateMachine, :_machinery_states, 0)
@@ -127,7 +131,7 @@ defmodule MachineryTest do
   end
 
   @tag :capture_log
-  test "Persist function should still reaise errors if not related to the existence of persist/1 method" do
+  test "Persist function should still raise errors if not related to the existence of persist/1 method" do
     wrong_struct = %TestStruct{my_state: "created", force_exception: true}
 
     assert_raise UndefinedFunctionError, fn ->
@@ -135,18 +139,18 @@ defmodule MachineryTest do
     end
   end
 
-  test "Transition log function should be called after the transition" do
-    struct = %TestStruct{my_state: "created"}
-    assert {:ok, _} = Machinery.transition_to(struct, TestStateMachineWithGuard, "partial")
-  end
-
   @tag :capture_log
-  test "Transition log function should still reaise errors if not related to the existence of persist/1 method" do
+  test "Transition log function should still raise errors if not related to the existence of persist/1 method" do
     wrong_struct = %TestStruct{my_state: "created", force_exception: true}
 
     assert_raise UndefinedFunctionError, fn ->
       Machinery.transition_to(wrong_struct, TestStateMachineWithGuard, "partial")
     end
+  end
+
+  test "Transition log function should be called after the transition" do
+    struct = %TestStruct{my_state: "created"}
+    assert {:ok, _} = Machinery.transition_to(struct, TestStateMachineWithGuard, "partial")
   end
 
   @tag :capture_log
@@ -157,7 +161,7 @@ defmodule MachineryTest do
 
   @tag :capture_log
   test "Machinery.Endpoint should be started under the Machinery.Supervisor if env var `interface` is set to true" do
-    Helper.mahcinery_interface()
+    Helper.machinery_interface()
     endpoint_pid = Process.whereis(Machinery.Endpoint)
     assert Process.alive?(endpoint_pid)
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,7 +16,7 @@ defmodule MachineryTest.Helper do
   alias MachineryTest.TestRepo
 
   @doc false
-  def mahcinery_interface(enable \\ true) do
+  def machinery_interface(enable \\ true) do
     Application.put_env(:machinery, :module, TestStateMachine)
     Application.put_env(:machinery, :model, TestStruct)
     Application.put_env(:machinery, :repo, TestRepo)
@@ -37,7 +37,7 @@ defmodule MachineryTest.Helper do
 
     receive do
       _ ->
-        :timer.sleep(1500)
+        :timer.sleep(5)
         Application.start(:machinery)
     end
   end

--- a/test/web/controllers/resource_controller_test.exs
+++ b/test/web/controllers/resource_controller_test.exs
@@ -7,7 +7,7 @@ defmodule MachineryTest.ResourceControllerTest do
   alias MachineryTest.Helper
 
   setup_all do
-    Helper.mahcinery_interface()
+    Helper.machinery_interface()
   end
 
   @tag :capture_log


### PR DESCRIPTION
This addresses two known bugs we had in the project.
- The flaky test that would break every now and then.
- Fixing a bug that was preventing people from overriding the `state` field for their resources.

This will make it easier for people trying to contribute to it in the future.