### PR TITLE
Resolve Machinery GenServer Get Timeout

### DIFF
--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -109,7 +109,7 @@ defmodule Machinery do
       struct,
       state_machine_module,
       next_state
-    })
+    }, :infinity)
   catch
     :exit, error_tuple ->
       exception = deep_first_of_tuple(error_tuple)


### PR DESCRIPTION
While using Machinery in the concurrent system, sometimes I am getting timeout errors.

Possibly due to there are many transition messages being sent to the gen_server, and/or before/after transitions are taking a long time to finish executions. 

This PR. will set Machinery GenServer timeout to `:infinity`. 