### PR TITLE
Call guard only in case of a valid transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build/*
 assets/*
 deps/*
 doc/*
+.elixir_ls


### PR DESCRIPTION
Currently, there is no way to block the transition based on the success of another operation because guard will be called even if the transition is invalid. `before_transition` cannot be used as it handles only `UndefinedFunctionError` and `FunctionClauseError` in the callback and raises any custom errors.