### PR TITLE
Don't execute guard transition if transition is not declared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build/*
 assets/*
 deps/*
 doc/*
+.elixir_ls

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -57,6 +57,14 @@ defmodule MachineryTest do
              Machinery.transition_to(completed_struct, TestStateMachine, "canceled")
   end
 
+  test "Guard functions should not be executed if the transition is invalid" do
+    IO.inspect("hh")
+    struct = %TestStruct{my_state: "created", missing_fields: true, force_exception: true}
+
+    assert {:error, _cause} =
+             Machinery.transition_to(struct, TestStateMachineWithGuard, "canceled")
+  end
+
   test "Guard functions should be executed before moving the resource to the next state" do
     struct = %TestStruct{my_state: "created", missing_fields: true}
 

--- a/test/support/test_state_machine_with_guard.exs
+++ b/test/support/test_state_machine_with_guard.exs
@@ -1,13 +1,27 @@
 defmodule MachineryTest.TestStateMachineWithGuard do
   use Machinery,
     field: :my_state,
-    states: ["created", "partial", "completed"],
+    states: ["created", "partial", "completed", "canceled"],
     transitions: %{
       "created" => ["partial", "completed"],
       "partial" => "completed"
     }
 
   def guard_transition(struct, "completed") do
+    # Code to simulate and force an exception inside a
+    # guard function.
+    if Map.get(struct, :force_exception) do
+      Machinery.non_existing_function_should_raise_error()
+    end
+
+    no_missing_fields = Map.get(struct, :missing_fields) == false
+
+    unless no_missing_fields do
+      {:error, "Guard Condition Custom Cause"}
+    end
+  end
+
+  def guard_transition(struct, "canceled") do
     # Code to simulate and force an exception inside a
     # guard function.
     if Map.get(struct, :force_exception) do


### PR DESCRIPTION
Currently, there is no way to block the transition based on the success of another operation because guard will be called even if the transition is invalid. `before_transition` cannot be used as it handles only `UndefinedFunctionError` and `FunctionClauseError` in the callback and raises any custom errors.