### PR TITLE
Adding extra metadata support for transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## WIP Version
 
+## 1.1.0
+- Adding extra metadata support for transitions - [Pull Request](https://github.com/joaomdmoura/machinery/pull/85)
+
 ## 1.0.0
 - Fixing overall TYPOs
 [Pull Request#1](https://github.com/joaomdmoura/machinery/pull/45)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add `:machinery` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:machinery, "~> 1.0.0"}
+    {:machinery, "~> 1.1.0"}
   ]
 end
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 config :machinery,
   interface: false

--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -85,21 +85,28 @@ defmodule Machinery do
     - `struct`: The `struct` you want to transit to another state.
     - `state_machine_module`: The module that holds the state machine logic, where Machinery as imported.
     - `next_state`: String of the next state you want to transition to.
+    - `extra_metadata`(optional): Map with extra data you might want to access in any of the Machinery functions (callbacks, guard, log, persist).
 
   ## Examples
 
       Machinery.transition_to(%User{state: :partial}, UserStateMachine, "completed")
       {:ok, %User{state: "completed"}}
+
+      # Or
+
+      Machinery.transition_to(%User{state: :partial}, UserStateMachine, "completed", %{verified: true})
+      {:ok, %User{state: "completed"}}
   """
-  @spec transition_to(struct, module, String.t()) :: {:ok, struct} | {:error, String.t()}
-  def transition_to(struct, state_machine_module, next_state) do
+  @spec transition_to(struct, module, String.t(), map()) :: {:ok, struct} | {:error, String.t()}
+  def transition_to(struct, state_machine_module, next_state, extra_metadata \\ %{}) do
     GenServer.call(
       Machinery.Transitions,
       {
         :run,
         struct,
         state_machine_module,
-        next_state
+        next_state,
+        extra_metadata
       },
       :infinity
     )

--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -98,7 +98,7 @@ defmodule Machinery do
       {:ok, %User{state: "completed"}}
   """
   @spec transition_to(struct, module, String.t(), map()) :: {:ok, struct} | {:error, String.t()}
-  def transition_to(struct, state_machine_module, next_state, extra_metadata \\ %{}) do
+  def transition_to(struct, state_machine_module, next_state, extra_metadata \\ None) do
     GenServer.call(
       Machinery.Transitions,
       {

--- a/lib/machinery/transition.ex
+++ b/lib/machinery/transition.ex
@@ -5,14 +5,6 @@ defmodule Machinery.Transition do
   This is meant to be for internal use only.
   """
 
-  @internal_functions [
-    :guard_transition,
-    :before_transition,
-    :after_transition,
-    :persist,
-    :log_transition
-  ]
-
   @doc """
   Function responsible for checking if the transition from a state to another
   was specifically declared.
@@ -34,7 +26,8 @@ defmodule Machinery.Transition do
   """
   @spec guarded_transition?(module, struct, atom, map()) :: boolean
   def guarded_transition?(module, struct, state, extra_metadata) do
-    function = if extra_metadata == None, do: &module.guard_transition/2, else: &module.guard_transition/3
+    function =
+      if extra_metadata == None, do: &module.guard_transition/2, else: &module.guard_transition/3
 
     case run_or_fallback(
            function,
@@ -56,7 +49,10 @@ defmodule Machinery.Transition do
   """
   @spec before_callbacks(struct, atom, module, map()) :: struct
   def before_callbacks(struct, state, module, extra_metadata) do
-    function = if extra_metadata == None, do: &module.before_transition/2, else: &module.before_transition/3
+    function =
+      if extra_metadata == None,
+        do: &module.before_transition/2,
+        else: &module.before_transition/3
 
     run_or_fallback(
       function,
@@ -75,7 +71,8 @@ defmodule Machinery.Transition do
   """
   @spec after_callbacks(struct, atom, module, map()) :: struct
   def after_callbacks(struct, state, module, extra_metadata) do
-    function = if extra_metadata == None, do: &module.after_transition/2, else: &module.after_transition/3
+    function =
+      if extra_metadata == None, do: &module.after_transition/2, else: &module.after_transition/3
 
     run_or_fallback(
       function,
@@ -112,8 +109,9 @@ defmodule Machinery.Transition do
   """
   @spec log_transition(struct, atom, module, map()) :: struct
   def log_transition(struct, state, module, extra_metadata) do
-    function = if extra_metadata == None, do: &module.log_transition/2, else: &module.log_transition/3
-    
+    function =
+      if extra_metadata == None, do: &module.log_transition/2, else: &module.log_transition/3
+
     run_or_fallback(
       function,
       &log_transition_fallback/4,
@@ -135,7 +133,7 @@ defmodule Machinery.Transition do
       :error -> false
     end
   end
-  
+
   # This function looks at the arity of a function and calls it with
   # the appropriate number of parameters, passing in the struct,
   # state, and extra_metadata. If the function throws an error,
@@ -152,7 +150,7 @@ defmodule Machinery.Transition do
   end
 
   defp persist_fallback(struct, state, error, field) do
-    if error.function == :persist && Enum.member?([2,3], error.arity) do
+    if error.function == :persist && Enum.member?([2, 3], error.arity) do
       Map.put(struct, field, state)
     else
       raise error
@@ -160,7 +158,7 @@ defmodule Machinery.Transition do
   end
 
   defp log_transition_fallback(struct, _state, error, _field) do
-    if error.function == :log_transition && Enum.member?([2,3], error.arity) do
+    if error.function == :log_transition && Enum.member?([2, 3], error.arity) do
       struct
     else
       raise error
@@ -168,7 +166,8 @@ defmodule Machinery.Transition do
   end
 
   defp callbacks_fallback(struct, _state, error, _field) do
-    if error.function in [:after_transition, :before_transition] && Enum.member?([2,3], error.arity) do
+    if error.function in [:after_transition, :before_transition] &&
+         Enum.member?([2, 3], error.arity) do
       struct
     else
       raise error
@@ -179,7 +178,7 @@ defmodule Machinery.Transition do
   # guard_transition/2 it will fallback returning true and
   # allowing the transition, otherwise it will raise the exception.
   defp guard_transition_fallback(_struct, _state, error, _field) do
-    if error.function == :guard_transition && Enum.member?([2,3], error.arity) do
+    if error.function == :guard_transition && Enum.member?([2, 3], error.arity) do
       true
     else
       raise error

--- a/lib/machinery/transition.ex
+++ b/lib/machinery/transition.ex
@@ -5,6 +5,14 @@ defmodule Machinery.Transition do
   This is meant to be for internal use only.
   """
 
+  @internal_functions [
+    :guard_transition,
+    :before_transition,
+    :after_transition,
+    :persist,
+    :log_transition
+  ]
+
   @doc """
   Function responsible for checking if the transition from a state to another
   was specifically declared.
@@ -24,14 +32,16 @@ defmodule Machinery.Transition do
   unless another existing guard condition exists.
   This is meant to be for internal use only.
   """
-  @spec guarded_transition?(module, struct, atom) :: boolean
-  def guarded_transition?(module, struct, state) do
+  @spec guarded_transition?(module, struct, atom, map()) :: boolean
+  def guarded_transition?(module, struct, state, extra_metadata) do
     case run_or_fallback(
+           &module.guard_transition/3,
            &module.guard_transition/2,
            &guard_transition_fallback/4,
            struct,
            state,
-           module._field()
+           module._field(),
+           extra_metadata
          ) do
       {:error, cause} -> {:error, cause}
       _ -> false
@@ -43,14 +53,16 @@ defmodule Machinery.Transition do
   fallback to a boilerplate behaviour.
   This is meant to be for internal use only.
   """
-  @spec before_callbacks(struct, atom, module) :: struct
-  def before_callbacks(struct, state, module) do
+  @spec before_callbacks(struct, atom, module, map()) :: struct
+  def before_callbacks(struct, state, module, extra_metadata) do
     run_or_fallback(
+      &module.before_transition/3,
       &module.before_transition/2,
       &callbacks_fallback/4,
       struct,
       state,
-      module._field()
+      module._field(),
+      extra_metadata
     )
   end
 
@@ -59,14 +71,16 @@ defmodule Machinery.Transition do
   fallback to a boilerplate behaviour.
   This is meant to be for internal use only.
   """
-  @spec after_callbacks(struct, atom, module) :: struct
-  def after_callbacks(struct, state, module) do
+  @spec after_callbacks(struct, atom, module, map()) :: struct
+  def after_callbacks(struct, state, module, extra_metadata) do
     run_or_fallback(
+      &module.after_transition/3,
       &module.after_transition/2,
       &callbacks_fallback/4,
       struct,
       state,
-      module._field()
+      module._field(),
+      extra_metadata
     )
   end
 
@@ -75,23 +89,33 @@ defmodule Machinery.Transition do
   changing state.
   This is meant to be for internal use only.
   """
-  @spec persist_struct(struct, atom, module) :: struct
-  def persist_struct(struct, state, module) do
-    run_or_fallback(&module.persist/2, &persist_fallback/4, struct, state, module._field())
+  @spec persist_struct(struct, atom, module, map()) :: struct
+  def persist_struct(struct, state, module, extra_metadata) do
+    run_or_fallback(
+      &module.persist/3,
+      &module.persist/2,
+      &persist_fallback/4,
+      struct,
+      state,
+      module._field(),
+      extra_metadata
+    )
   end
 
   @doc """
   Function responsible for triggering transitions persistence.
   This is meant to be for internal use only.
   """
-  @spec log_transition(struct, atom, module) :: struct
-  def log_transition(struct, state, module) do
+  @spec log_transition(struct, atom, module, map()) :: struct
+  def log_transition(struct, state, module, extra_metadata) do
     run_or_fallback(
+      &module.log_transition/3,
       &module.log_transition/2,
       &log_transition_fallback/4,
       struct,
       state,
-      module._field()
+      module._field(),
+      extra_metadata
     )
   end
 
@@ -106,13 +130,24 @@ defmodule Machinery.Transition do
       :error -> false
     end
   end
+  
+  # run_or_fallback takes a function and a callback, and
+  # runs the function. If the function raises an error, it
+  # runs the callback with the error as an argument.
+  defp run_or_fallback(func, deprecated_func, callback, struct, state, field, extra_metadata) do
+    func.(struct, state, extra_metadata)
+  rescue
+    error in UndefinedFunctionError ->
+      if Enum.member?(@internal_functions, error.function) && error.arity == 3 do
+        deprecated_run_or_fallback(deprecated_func, callback, struct, state, field)
+      else
+        callback.(struct, state, error, field)
+      end
+    error in FunctionClauseError -> callback.(struct, state, error, field)
+  end
 
-  # Private function that receives a function, a callback,
-  # a struct and the related state. It tries to execute the function,
-  # rescue for a couple of specific Exceptions and passes it forward
-  # to the callback, that will re-raise it if not related to
-  # guard_transition nor before | after call backs
-  defp run_or_fallback(func, callback, struct, state, field) do
+  # This function is deprecated and will be removed in the next major release.
+  defp deprecated_run_or_fallback(func, callback, struct, state, field) do
     func.(struct, state)
   rescue
     error in UndefinedFunctionError -> callback.(struct, state, error, field)
@@ -120,7 +155,7 @@ defmodule Machinery.Transition do
   end
 
   defp persist_fallback(struct, state, error, field) do
-    if error.function == :persist && error.arity == 2 do
+    if error.function == :persist && Enum.member?([2,3], error.arity) do
       Map.put(struct, field, state)
     else
       raise error
@@ -128,7 +163,7 @@ defmodule Machinery.Transition do
   end
 
   defp log_transition_fallback(struct, _state, error, _field) do
-    if error.function == :log_transition && error.arity == 2 do
+    if error.function == :log_transition && Enum.member?([2,3], error.arity) do
       struct
     else
       raise error
@@ -136,7 +171,7 @@ defmodule Machinery.Transition do
   end
 
   defp callbacks_fallback(struct, _state, error, _field) do
-    if error.function in [:after_transition, :before_transition] && error.arity == 2 do
+    if error.function in [:after_transition, :before_transition] && Enum.member?([2,3], error.arity) do
       struct
     else
       raise error
@@ -147,7 +182,7 @@ defmodule Machinery.Transition do
   # guard_transition/2 it will fallback returning true and
   # allowing the transition, otherwise it will raise the exception.
   defp guard_transition_fallback(_struct, _state, error, _field) do
-    if error.function == :guard_transition && error.arity == 2 do
+    if error.function == :guard_transition && Enum.member?([2,3], error.arity) do
       true
     else
       raise error

--- a/lib/machinery/transitions.ex
+++ b/lib/machinery/transitions.ex
@@ -20,7 +20,7 @@ defmodule Machinery.Transitions do
   end
 
   @doc false
-  def handle_call({:run, struct, state_machine_module, next_state}, _from, states) do
+  def handle_call({:run, struct, state_machine_module, next_state, extra_metadata}, _from, states) do
     initial_state = state_machine_module._machinery_initial_state()
     transitions = state_machine_module._machinery_transitions()
     state_field = state_machine_module._field()
@@ -40,17 +40,17 @@ defmodule Machinery.Transitions do
     response =
       if declared_transition? do
         guarded_transition? =
-          Transition.guarded_transition?(state_machine_module, struct, next_state)
+          Transition.guarded_transition?(state_machine_module, struct, next_state, extra_metadata)
 
         if guarded_transition? do
           guarded_transition?
         else
           struct =
             struct
-            |> Transition.before_callbacks(next_state, state_machine_module)
-            |> Transition.persist_struct(next_state, state_machine_module)
-            |> Transition.log_transition(next_state, state_machine_module)
-            |> Transition.after_callbacks(next_state, state_machine_module)
+            |> Transition.before_callbacks(next_state, state_machine_module, extra_metadata)
+            |> Transition.persist_struct(next_state, state_machine_module, extra_metadata)
+            |> Transition.log_transition(next_state, state_machine_module, extra_metadata)
+            |> Transition.after_callbacks(next_state, state_machine_module, extra_metadata)
 
           {:ok, struct}
         end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Machinery.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/joaomdmoura/machinery"
-  @version "1.0.0"
+  @version "1.1.0"
 
   def project do
     [
@@ -32,8 +32,8 @@ defmodule Machinery.Mixfile do
   defp package() do
     [
       description:
-        "Machinery is a State Machine library for structs in general." <>
-          "It supports guard clauses, callbacks and integrate out of the box" <>
+        "Machinery is a State Machine library for structs in general. " <>
+          "It supports guard clauses, callbacks and integrate out of the box " <>
           "with Phoenix apps.",
       maintainers: ["João M. D. Moura"],
       licenses: ["Apache-2.0"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machinery",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Machinery is a State Machine library for structs in general. It supports guard clauses, callbacks and integrate out of the box with Phoenix apps.",
   "main": "index.js",
   "directories": {

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -60,33 +60,77 @@ defmodule MachineryTest do
 
   test "Transition to should support extra metadata in the persist function" do
     struct = %TestStruct{my_state: "created", missing_fields: false}
-    _expected_struct = %TestStruct{my_state: "canceled", missing_fields: false, extra: "metadata", persist: true}
-    {:ok, updated_struct} = Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "canceled", %{extra: "metadata"})
+
+    _expected_struct = %TestStruct{
+      my_state: "canceled",
+      missing_fields: false,
+      extra: "metadata",
+      persist: true
+    }
+
+    {:ok, updated_struct} =
+      Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "canceled", %{
+        extra: "metadata"
+      })
 
     assert _expected_struct = updated_struct
   end
 
   test "Transition to should support extra metadata in the before transition function" do
     struct = %TestStruct{my_state: "created"}
-    _expected_struct = %TestStruct{my_state: "partial", missing_fields: true, extra: "metadata", persist: true, before_transition: true}
-    {:ok, updated_struct} = Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "partial", %{extra: "metadata"})
+
+    _expected_struct = %TestStruct{
+      my_state: "partial",
+      missing_fields: true,
+      extra: "metadata",
+      persist: true,
+      before_transition: true
+    }
+
+    {:ok, updated_struct} =
+      Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "partial", %{
+        extra: "metadata"
+      })
 
     assert _expected_struct = updated_struct
   end
 
   test "Transition to should support extra metadata in the after transition function" do
     struct = %TestStruct{my_state: "created"}
-    _expected_struct = %TestStruct{my_state: "completed", missing_fields: false, extra: "metadata", persist: true,  after_transition: true, guard_tranistion: true}
-    {:ok, updated_struct} = Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "completed", %{extra: "metadata"})
-  
+
+    _expected_struct = %TestStruct{
+      my_state: "completed",
+      missing_fields: false,
+      extra: "metadata",
+      persist: true,
+      after_transition: true,
+      guard_tranistion: true
+    }
+
+    {:ok, updated_struct} =
+      Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "completed", %{
+        extra: "metadata"
+      })
+
     assert _expected_struct = updated_struct
   end
 
   test "Transition to should support extra metadata in the log function" do
     struct = %TestStruct{my_state: "created"}
-    _expected_struct = %TestStruct{my_state: "canceled", missing_fields: false, extra: "metadata", persist: true,  log: true}
-    {:ok, updated_struct} = Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "canceled", %{extra: "metadata"})
-  
+
+    _expected_struct = %TestStruct{
+      my_state: "canceled",
+      missing_fields: false,
+      extra: "metadata",
+      persist: true,
+      log: true
+    }
+
+    {:ok, updated_struct} =
+      Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "canceled", %{
+        extra: "metadata"
+      })
+
     assert _expected_struct = updated_struct
   end
 

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -76,7 +76,7 @@ defmodule MachineryTest do
 
   test "Transition to should support extra metadata in the after transition function" do
     struct = %TestStruct{my_state: "created"}
-    _expected_struct = %TestStruct{my_state: "completed", missing_fields: false, extra: "metadata", persist: true,  after_transition: true}
+    _expected_struct = %TestStruct{my_state: "completed", missing_fields: false, extra: "metadata", persist: true,  after_transition: true, guard_tranistion: true}
     {:ok, updated_struct} = Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "completed", %{extra: "metadata"})
   
     assert _expected_struct = updated_struct

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -7,6 +7,7 @@ defmodule MachineryTest do
   alias MachineryTest.TestStateMachine
   alias MachineryTest.TestStateMachineDefaultField
   alias MachineryTest.TestStateMachineWithGuard
+  alias MachineryTest.TestStateMachineWithExtraMetadata
   alias MachineryTest.TestStruct
 
   setup do
@@ -55,6 +56,38 @@ defmodule MachineryTest do
 
     assert {:ok, %TestStruct{my_state: "canceled"}} =
              Machinery.transition_to(completed_struct, TestStateMachine, "canceled")
+  end
+
+  test "Transition to should support extra metadata in the persist function" do
+    struct = %TestStruct{my_state: "created", missing_fields: false}
+    _expected_struct = %TestStruct{my_state: "canceled", missing_fields: false, extra: "metadata", persist: true}
+    {:ok, updated_struct} = Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "canceled", %{extra: "metadata"})
+
+    assert _expected_struct = updated_struct
+  end
+
+  test "Transition to should support extra metadata in the before transition function" do
+    struct = %TestStruct{my_state: "created"}
+    _expected_struct = %TestStruct{my_state: "partial", missing_fields: true, extra: "metadata", persist: true, before_transition: true}
+    {:ok, updated_struct} = Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "partial", %{extra: "metadata"})
+
+    assert _expected_struct = updated_struct
+  end
+
+  test "Transition to should support extra metadata in the after transition function" do
+    struct = %TestStruct{my_state: "created"}
+    _expected_struct = %TestStruct{my_state: "completed", missing_fields: false, extra: "metadata", persist: true,  after_transition: true}
+    {:ok, updated_struct} = Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "completed", %{extra: "metadata"})
+  
+    assert _expected_struct = updated_struct
+  end
+
+  test "Transition to should support extra metadata in the log function" do
+    struct = %TestStruct{my_state: "created"}
+    _expected_struct = %TestStruct{my_state: "canceled", missing_fields: false, extra: "metadata", persist: true,  log: true}
+    {:ok, updated_struct} = Machinery.transition_to(struct, TestStateMachineWithExtraMetadata, "canceled", %{extra: "metadata"})
+  
+    assert _expected_struct = updated_struct
   end
 
   test "Guard functions should not be executed if the transition is invalid" do

--- a/test/support/test_state_machine_with_extra_metadata.exs
+++ b/test/support/test_state_machine_with_extra_metadata.exs
@@ -1,0 +1,34 @@
+defmodule MachineryTest.TestStateMachineWithExtraMetadata do
+  use Machinery,
+    field: :my_state,
+    states: ["created", "partial", "completed", "canceled"],
+    transitions: %{
+      "created" => ["partial", "completed"],
+      "partial" => "completed",
+      "*" => "canceled"
+    }
+
+  def before_transition(struct, "partial", extra) do
+    extra = Map.put(extra, :before_transition, true)
+    struct = Map.merge(struct, extra)
+    Map.put(struct, :missing_fields, true)
+  end
+
+  def after_transition(struct, "completed", extra) do
+    extra = Map.put(extra, :after_transition, true)
+    struct = Map.merge(struct, extra)
+    Map.put(struct, :missing_fields, false)
+  end
+
+  def persist(struct, next_state, extra) do
+    extra = Map.put(extra, :persist, true)
+    struct = Map.merge(struct, extra)
+    Map.put(struct, :my_state, next_state)
+  end
+
+  def log_transition(struct, _next_state, extra) do
+    extra = Map.put(extra, :log, true)
+    struct = Map.merge(struct, extra)
+    Map.merge(struct, extra)
+  end
+end

--- a/test/support/test_state_machine_with_extra_metadata.exs
+++ b/test/support/test_state_machine_with_extra_metadata.exs
@@ -31,4 +31,9 @@ defmodule MachineryTest.TestStateMachineWithExtraMetadata do
     struct = Map.merge(struct, extra)
     Map.merge(struct, extra)
   end
+
+  def guard_transition(struct, "completed", extra) do
+    extra = Map.put(extra, :guard_transition, true)
+    Map.merge(struct, extra)
+  end
 end

--- a/test/support/test_struct.exs
+++ b/test/support/test_struct.exs
@@ -11,6 +11,7 @@ defmodule MachineryTest.TestStruct do
     field(:after_transition, :boolean)
     field(:persist, :boolean)
     field(:log, :boolean)
+    field(:guard_tranistion, :boolean)
     timestamps()
   end
 
@@ -24,7 +25,8 @@ defmodule MachineryTest.TestStruct do
       :before_transition,
       :after_transition,
       :persist,
-      :log
+      :log,
+      :guard_tranistion
     ])
   end
 end

--- a/test/support/test_struct.exs
+++ b/test/support/test_struct.exs
@@ -6,11 +6,25 @@ defmodule MachineryTest.TestStruct do
     field(:my_state, :string)
     field(:missing_fields, :boolean)
     field(:force_exception, :boolean)
+    field(:extra, :string)
+    field(:before_transition, :boolean)
+    field(:after_transition, :boolean)
+    field(:persist, :boolean)
+    field(:log, :boolean)
     timestamps()
   end
 
   @doc false
   def changeset(test_struct, attrs) do
-    cast(test_struct, attrs, [:my_state, :missing_fields, :force_exception])
+    cast(test_struct, attrs, [
+      :my_state,
+      :missing_fields,
+      :force_exception,
+      :extra,
+      :before_transition,
+      :after_transition,
+      :persist,
+      :log
+    ])
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,12 +1,13 @@
 ExUnit.start()
 
 # Load support modules
-Code.load_file("test/support/test_struct.exs")
-Code.load_file("test/support/test_default_field_struct.exs")
-Code.load_file("test/support/test_state_machine.exs")
-Code.load_file("test/support/test_state_machine_with_guard.exs")
-Code.load_file("test/support/test_state_machine_default_field.exs")
-Code.load_file("test/support/test_repo.exs")
+Code.require_file("test/support/test_struct.exs")
+Code.require_file("test/support/test_default_field_struct.exs")
+Code.require_file("test/support/test_state_machine.exs")
+Code.require_file("test/support/test_state_machine_with_guard.exs")
+Code.require_file("test/support/test_state_machine_default_field.exs")
+Code.require_file("test/support/test_state_machine_with_extra_metadata.exs")
+Code.require_file("test/support/test_repo.exs")
 
 defmodule MachineryTest.Helper do
   import ExUnit.CaptureLog


### PR DESCRIPTION
This is inspired on #70 but implemented in a way that doesn't break existing implementations.

It allows you to add extra metadata in the format of a map to the transitions:
```elixir
Machinery.transition_to(struct, TestStateMachine, "canceled", %{extra: "metadata"})
```

This extra metadata will then be broadcasted to all the functions supported on the state machine module, allowing you to choose to have a function signature with three arguments now:
```elixir
def before_transition(struct, next_state, extra) do
# ...

def persist_transition(struct, next_state, extra) do
# ...

def before_transition(struct, next_state, extra) do
# ...

def log_transition(struct, next_state, extra) do
# ...

def guard_transition(struct, next_state, extra) do
# ...
```
