### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,11 @@
 - Better treating the JSON return for the Dashboard - [Pull Request](https://github.com/joaomdmoura/machinery/pull/27)
 
 ## 0.12.0
-- Adding new toogle all btn and auto closing alerts - [Pull Request](https://github.com/joaomdmoura/machinery/pull/24)
+- Adding new toggle all btn and auto closing alerts - [Pull Request](https://github.com/joaomdmoura/machinery/pull/24)
 - Fixing Bug to rollback state transition on the Dashboard - [Pull Request](https://github.com/joaomdmoura/machinery/pull/25)
 
 ## 0.11.0
-- Adding a default config desabling the Machinery Dashboard
+- Adding a default config disabling the Machinery Dashboard
 - Making the Machinery Dashboard bigger
 - Enabling users to overwrite the desired state on Machinery Dashboard - [Pull Request](https://github.com/joaomdmoura/machinery/pull/21)
 - Adding the ability to change states form Dashboard - [Pull Request](https://github.com/joaomdmoura/machinery/pull/22)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@ You may also want to start with something small like updating docs or the README
 
 If you have a feature you would like to see implemented, before jumping into the code,
 it's highly recommended that you open an issue describing your reasons, benefits and drawbacks.
-That way, we as a community can check your proposal and give you some feedback, that is extremelly
+That way, we as a community can check your proposal and give you some feedback, that is extremely
 helpful to achieve better ideas and also keeps you of doing code that might not be approved because
 of many reasons.
 
 ## Bug Report
 
-Bugs should also be reported through issues, that sould contain how to replicate the bug and some
+Bugs should also be reported through issues, that should contain how to replicate the bug and some
 trace of the error.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ It takes the following arguments:
 - `struct`: The `struct` you want to transition to another state.
 - `state_machine_module`: The module that holds the state machine logic, where Machinery is imported.
 - `next_event`: `string` of the next state you want the struct to transition to.
-- *(optional)* `extra_metadata`: `map` with any extra data you might want to access on any of the sate machine functions triggered by the state change
+- *(optional)* `extra_metadata`: `map` with any extra data you might want to access on any of the state machine functions triggered by the state change
 
 ```elixir
 Machinery.transition_to(your_struct, YourStateMachine, "next_state")

--- a/lib/machinery.ex
+++ b/lib/machinery.ex
@@ -21,7 +21,7 @@ defmodule Machinery do
     defmodule YourProject.UserStateMachine do
       use Machinery,
         # The first state declared will be considered
-        # the intial state
+        # the initial state
         states: ["created", "partial", "complete"],
         transitions: %{
           "created" =>  ["partial", "complete"],

--- a/lib/machinery/transitions.ex
+++ b/lib/machinery/transitions.ex
@@ -8,7 +8,7 @@ defmodule Machinery.Transitions do
   use GenServer
   alias Machinery.Transition
 
-  @not_declated_error "Transition to this state isn't declared."
+  @not_declared_error "Transition to this state isn't declared."
 
   def init(args) do
     {:ok, args}
@@ -55,7 +55,7 @@ defmodule Machinery.Transitions do
           {:ok, struct}
         end
       else
-        {:error, @not_declated_error}
+        {:error, @not_declared_error}
       end
 
     {:reply, response, states}

--- a/test/machinery_test.exs
+++ b/test/machinery_test.exs
@@ -104,7 +104,7 @@ defmodule MachineryTest do
       extra: "metadata",
       persist: true,
       after_transition: true,
-      guard_tranistion: true
+      guard_transition: true
     }
 
     {:ok, updated_struct} =
@@ -181,7 +181,7 @@ defmodule MachineryTest do
   end
 
   @tag :capture_log
-  test "Implict rescue on the guard clause internals should raise any other excepetion not strictly related to missing guard_tranistion/2 existence" do
+  test "Implicit rescue on the guard clause internals should raise any other exception not strictly related to missing guard_transition/2 existence" do
     wrong_struct = %TestStruct{my_state: "created", force_exception: true}
 
     assert_raise UndefinedFunctionError, fn ->
@@ -201,7 +201,7 @@ defmodule MachineryTest do
   end
 
   @tag :capture_log
-  test "Implict rescue on the callbacks internals should raise any other excepetion not strictly related to missing callbacks_fallback/2 existence" do
+  test "Implicit rescue on the callbacks internals should raise any other exception not strictly related to missing callbacks_fallback/2 existence" do
     wrong_struct = %TestStruct{my_state: "created", force_exception: true}
 
     assert_raise UndefinedFunctionError, fn ->

--- a/test/support/test_struct.exs
+++ b/test/support/test_struct.exs
@@ -11,7 +11,7 @@ defmodule MachineryTest.TestStruct do
     field(:after_transition, :boolean)
     field(:persist, :boolean)
     field(:log, :boolean)
-    field(:guard_tranistion, :boolean)
+    field(:guard_transition, :boolean)
     timestamps()
   end
 
@@ -26,7 +26,7 @@ defmodule MachineryTest.TestStruct do
       :after_transition,
       :persist,
       :log,
-      :guard_tranistion
+      :guard_transition
     ])
   end
 end


### PR DESCRIPTION
Found via `codespell` and `typos --format brief`